### PR TITLE
Add support for light size for Inverse Square Lighting

### DIFF
--- a/src/LightData.cpp
+++ b/src/LightData.cpp
@@ -219,7 +219,19 @@ bool LightData::GetInverseSquare() const
 float LightData::GetCutoff() const
 {
 	const float lightCutoff = cutoff > 0.0f ? cutoff : light->data.fallofExponent;
-	return std::min(std::max(lightCutoff, 0.01f), 1.0f);
+	return std::clamp(lightCutoff, 0.01f, 1.0f);
+}
+
+float LightData::GetSize() const
+{
+	float lightSize = size > 0.0f ? size : light->data.fov;
+	lightSize = lightSize >= 50.0f ? 1.414f : lightSize;
+	return std::clamp(lightSize, 0.01f, 50.0f);
+}
+
+float LightData::GetScaledSize(float a_scale) const
+{
+	return GetScaledValue(GetSize(), a_scale);
 }
 
 float LightData::GetFalloff() const
@@ -287,7 +299,7 @@ LightOutput LightData::GenLight(RE::TESObjectREFR* a_ref, RE::NiNode* a_node, st
 		const auto lightRadius = GetScaledRadius(a_scale);
 		niLight->radius.x = lightRadius;
 		niLight->radius.y = lightRadius;
-		niLight->radius.z = lightRadius;
+		niLight->radius.z = GetScaledSize(a_scale);
 
 		niLight->SetLightAttenuation(lightRadius);
 		niLight->fade = GetScaledFade(a_scale);

--- a/src/LightData.h
+++ b/src/LightData.h
@@ -93,6 +93,8 @@ struct LightData
 	LIGHT_FLAGS                              GetLightFlags() const;
 	bool                                     GetInverseSquare() const;
 	float                                    GetCutoff() const;
+	float                                    GetSize() const;
+	float                                    GetScaledSize(float a_scale) const;
 	float                                    GetFalloff() const;
 	float                                    GetNearDistance() const;
 	static std::string                       GetLightName(const std::unique_ptr<SourceAttachData>& a_srcData, std::string_view a_lightEDID, std::uint32_t a_index);
@@ -116,6 +118,7 @@ struct LightData
 	float                                    fade{ 0.0f };
 	float                                    fov{ 0.0f };
 	float                                    cutoff{ 0.0f };
+	float                                    size{ 0.0f };
 	float                                    shadowDepthBias{ 1.0f };
 	RE::NiPoint3                             offset;
 	RE::NiMatrix3                            rotation;
@@ -264,6 +267,7 @@ struct glz::meta<LIGH::LightSourceData>
 		"fade", [](auto&& self) -> auto& { return self.data.fade; },
 		"fov", [](auto&& self) -> auto& { return self.data.fov; },
 		"cutoff", [](auto&& self) -> auto& { return self.data.cutoff; },
+		"size", [](auto&& self) -> auto& { return self.data.size; },
 		"shadowDepthBias", [](auto&& self) -> auto& { return self.data.shadowDepthBias; },
 		"offset", [](auto&& self) -> auto& { return self.data.offset; },
 		"rotation", [](auto&& self) -> auto& { return self.data.rotation; },


### PR DESCRIPTION
* Adds a new parameter for Inverse Square Lighting to control the size of a light source
* Stored in unused radius blue channel
* Includes new JSON setting
* Fully backwards compatible with CS and existing lighting JSONs
* Tested on SE/AE/VR